### PR TITLE
Don't export Priority in top-level module

### DIFF
--- a/src/Data/LruCache.hs
+++ b/src/Data/LruCache.hs
@@ -12,7 +12,6 @@ Pure API to an LRU cache.
 -}
 module Data.LruCache
   ( LruCache
-  , Priority
   , empty
   , insert
   , insertView


### PR DESCRIPTION
The module exports `Priority` but it can't be used without importing
internals (which also export `Priority`). Hide it to avoid confusion.