### PR TITLE
Bump base-compat and hashable upper bounds

### DIFF
--- a/lrucaching.cabal
+++ b/lrucaching.cabal
@@ -22,7 +22,7 @@ library
                        Data.LruCache.IO.Finalizer
                        Data.LruCache.Internal
   build-depends:       base        >= 4.8  && < 5
-                     , base-compat >= 0.9  && < 0.14
+                     , base-compat >= 0.9  && < 0.16
                      , deepseq     >= 1.4  && < 1.6
                      , hashable    >= 1.2  && < 1.5
                      , psqueues    >= 0.2  && < 0.3


### PR DESCRIPTION
There's no local testing target for this, just a complicated Travis setup, so I'll rely on merge CI checks for correctness. I forced use of this on one of my projects with Stackage LTS 24, and it seemed to at least compile, so let's give it a try. Would be good to document testing procedure for upgrades.